### PR TITLE
Develop

### DIFF
--- a/src/components/features/home/GitHubCalendar.astro
+++ b/src/components/features/home/GitHubCalendar.astro
@@ -94,7 +94,7 @@ function getColorForLevel(level: number): { light: string; dark: string } {
 	};
 }
 
-const svgWidth = weeks.length * (blockSize + blockMargin) - blockMargin;
+const svgWidth = Math.max(blockSize, weeks.length * (blockSize + blockMargin) - blockMargin);
 const svgHeight = 7 * (blockSize + blockMargin) - blockMargin;
 const topPadding = showMonthLabels ? blockSize + 8 : 0;
 ---
@@ -118,7 +118,7 @@ const topPadding = showMonthLabels ? blockSize + 8 : 0;
 		<svg
 			class="mb-2"
 			width="100%"
-			height="auto"
+			height="100%"
 			viewBox={`0 0 ${svgWidth} ${svgHeight + topPadding}`}
 			preserveAspectRatio="xMidYMid meet"
 			xmlns="http://www.w3.org/2000/svg"
@@ -148,9 +148,6 @@ const topPadding = showMonthLabels ? blockSize + 8 : 0;
 						const x = weekIndex * (blockSize + blockMargin);
 						const y = topPadding + dayIndex * (blockSize + blockMargin);
 						const level = activity?.level ?? 0;
-						const tooltipText = activity
-							? `${activity.count} contributions on ${formatDate(activity.date)}`
-							: "No data";
 
 						return (
 							<rect
@@ -160,13 +157,11 @@ const topPadding = showMonthLabels ? blockSize + 8 : 0;
 								height={blockSize}
 								rx="2"
 								ry="2"
-								class={`calendar-level-${level} cursor-help transition-opacity hover:opacity-80`}
+								class={`calendar-level-${level} transition-opacity hover:opacity-80`}
 								data-date={activity?.date ?? ""}
 								data-count={activity?.count ?? 0}
 								data-level={level}
-							>
-								<title>{tooltipText}</title>
-							</rect>
+							/>
 						);
 					}),
 				)
@@ -176,7 +171,7 @@ const topPadding = showMonthLabels ? blockSize + 8 : 0;
 		<!-- Stats -->
 		{
 			showTotalCount && (
-				<div class="text-muted-foreground mt-4 flex flex-row items-center justify-between gap-1 text-xs">
+				<div class="text-muted-foreground mt-4 flex flex-col items-center justify-between gap-1 text-xs md:flex-row">
 					<p>
 						<strong>{totalCount}</strong> contributions in {yearLabel}
 					</p>

--- a/src/components/features/home/GitHubCalendar.astro
+++ b/src/components/features/home/GitHubCalendar.astro
@@ -1,0 +1,259 @@
+---
+import {
+	fetchGitHubContributions,
+	formatDate,
+	getTotalCount,
+	groupByWeeks,
+} from "@/lib/github-calendar";
+
+type CalendarTheme = {
+	light: readonly [string, string, string, string, string];
+	dark?: readonly [string, string, string, string, string];
+};
+
+interface Props {
+	username: string;
+	year?: number | "last";
+	blockSize?: number;
+	blockMargin?: number;
+	showTotalCount?: boolean;
+	showMonthLabels?: boolean;
+	theme?: CalendarTheme;
+}
+
+const defaultTheme: CalendarTheme = {
+	light: ["rgba(235, 237, 240, 0.4)", "#c6e48b", "#7bc96f", "#239a3b", "#196127"],
+	dark: ["rgba(22, 27, 34, 0.8)", "#0e4429", "#006d32", "#26a641", "#39d353"],
+};
+
+const {
+	username,
+	year = "last",
+	blockSize = 14,
+	blockMargin = 3,
+	showTotalCount = true,
+	showMonthLabels = true,
+	theme = defaultTheme,
+} = Astro.props;
+
+const activities = await fetchGitHubContributions(username, year);
+const weeks = groupByWeeks(activities);
+const totalCount = getTotalCount(activities);
+
+const yearLabel = year === "last" ? "the last year" : `${year}`;
+
+const resolvedTheme: Required<CalendarTheme> = {
+	light: theme.light,
+	dark: theme.dark ?? theme.light,
+};
+
+const monthLabels = [
+	"Jan",
+	"Feb",
+	"Mar",
+	"Apr",
+	"May",
+	"Jun",
+	"Jul",
+	"Aug",
+	"Sep",
+	"Oct",
+	"Nov",
+	"Dec",
+];
+
+const monthLabelWeeks = new Map<number, number>();
+
+weeks.forEach((week, weekIndex) => {
+	const firstActivityInWeek = week.find((activity) => activity !== undefined);
+	if (!firstActivityInWeek) return;
+
+	const month = new Date(`${firstActivityInWeek.date}T00:00:00`).getMonth();
+	if (!monthLabelWeeks.has(month)) {
+		monthLabelWeeks.set(month, weekIndex);
+	}
+});
+
+const monthLabelEntries = Array.from(monthLabelWeeks.entries())
+	.sort(([, leftWeekIndex], [, rightWeekIndex]) => leftWeekIndex - rightWeekIndex)
+	.map(([month, weekIndex], entryIndex, entries) => {
+		const nextWeekIndex = entries[entryIndex + 1]?.[1];
+		const span = (nextWeekIndex ?? weekIndex + 4) - weekIndex;
+		return {
+			month,
+			weekIndex,
+			centerX: (weekIndex + span / 2) * (blockSize + blockMargin),
+		};
+	});
+
+function getColorForLevel(level: number): { light: string; dark: string } {
+	const safeLevel = Math.max(0, Math.min(level, 4));
+	return {
+		light: resolvedTheme.light[safeLevel],
+		dark: resolvedTheme.dark[safeLevel],
+	};
+}
+
+const svgWidth = weeks.length * (blockSize + blockMargin) - blockMargin;
+const svgHeight = 7 * (blockSize + blockMargin) - blockMargin;
+const topPadding = showMonthLabels ? blockSize + 8 : 0;
+---
+
+<div
+	class="w-full"
+	style={{
+		"--calendar-level-0-light": resolvedTheme.light[0],
+		"--calendar-level-1-light": resolvedTheme.light[1],
+		"--calendar-level-2-light": resolvedTheme.light[2],
+		"--calendar-level-3-light": resolvedTheme.light[3],
+		"--calendar-level-4-light": resolvedTheme.light[4],
+		"--calendar-level-0-dark": resolvedTheme.dark[0],
+		"--calendar-level-1-dark": resolvedTheme.dark[1],
+		"--calendar-level-2-dark": resolvedTheme.dark[2],
+		"--calendar-level-3-dark": resolvedTheme.dark[3],
+		"--calendar-level-4-dark": resolvedTheme.dark[4],
+	}}
+>
+	<div class="w-full min-w-0">
+		<svg
+			class="mb-2"
+			width="100%"
+			height="auto"
+			viewBox={`0 0 ${svgWidth} ${svgHeight + topPadding}`}
+			preserveAspectRatio="xMidYMid meet"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<!-- Month labels -->
+			{
+				showMonthLabels &&
+					monthLabelEntries.map((entry) => (
+						<text
+							x={entry.centerX}
+							y={blockSize * 0.7}
+							class="calendar-month-label"
+							font-size="12"
+							font-weight="400"
+							text-anchor="middle"
+							dominant-baseline="middle"
+						>
+							{monthLabels[entry.month]}
+						</text>
+					))
+			}
+
+			<!-- Contribution blocks -->
+			{
+				weeks.map((week, weekIndex) =>
+					week.map((activity, dayIndex) => {
+						const x = weekIndex * (blockSize + blockMargin);
+						const y = topPadding + dayIndex * (blockSize + blockMargin);
+						const level = activity?.level ?? 0;
+						const tooltipText = activity
+							? `${activity.count} contributions on ${formatDate(activity.date)}`
+							: "No data";
+
+						return (
+							<rect
+								x={x}
+								y={y}
+								width={blockSize}
+								height={blockSize}
+								rx="2"
+								ry="2"
+								class={`calendar-level-${level} cursor-help transition-opacity hover:opacity-80`}
+								data-date={activity?.date ?? ""}
+								data-count={activity?.count ?? 0}
+								data-level={level}
+							>
+								<title>{tooltipText}</title>
+							</rect>
+						);
+					}),
+				)
+			}
+		</svg>
+
+		<!-- Stats -->
+		{
+			showTotalCount && (
+				<div class="text-muted-foreground mt-4 flex flex-row items-center justify-between gap-1 text-xs">
+					<p>
+						<strong>{totalCount}</strong> contributions in {yearLabel}
+					</p>
+					<div class="flex items-center gap-2">
+						<span>Less</span>
+						{[0, 1, 2, 3, 4].map((level) => {
+							const colors = getColorForLevel(level);
+							return (
+								<div
+									class="h-3 w-3 rounded"
+									style={{
+										backgroundColor: colors.dark,
+									}}
+									title={`Level ${level}`}
+								/>
+							);
+						})}
+						<span>More</span>
+					</div>
+				</div>
+			)
+		}
+	</div>
+</div>
+
+<style scoped>
+	svg {
+		display: block;
+		margin: 0 auto;
+	}
+
+	rect {
+		stroke: transparent;
+		stroke-width: 0;
+	}
+
+	.calendar-level-0 {
+		fill: var(--calendar-level-0-light);
+	}
+
+	.calendar-level-1 {
+		fill: var(--calendar-level-1-light);
+	}
+
+	.calendar-level-2 {
+		fill: var(--calendar-level-2-light);
+	}
+
+	.calendar-level-3 {
+		fill: var(--calendar-level-3-light);
+	}
+
+	.calendar-level-4 {
+		fill: var(--calendar-level-4-light);
+	}
+
+	:global(.dark) .calendar-level-0 {
+		fill: var(--calendar-level-0-dark);
+	}
+
+	:global(.dark) .calendar-level-1 {
+		fill: var(--calendar-level-1-dark);
+	}
+
+	:global(.dark) .calendar-level-2 {
+		fill: var(--calendar-level-2-dark);
+	}
+
+	:global(.dark) .calendar-level-3 {
+		fill: var(--calendar-level-3-dark);
+	}
+
+	:global(.dark) .calendar-level-4 {
+		fill: var(--calendar-level-4-dark);
+	}
+
+	.calendar-month-label {
+		fill: hsl(var(--foreground));
+	}
+</style>

--- a/src/components/features/home/SkillsTabs.astro
+++ b/src/components/features/home/SkillsTabs.astro
@@ -1,0 +1,126 @@
+---
+import type { Skill, SkillCollection } from "@/lib/constants/tech-stack";
+import { cn } from "@/lib/utils";
+
+interface Props {
+	collections: SkillCollection[];
+	class?: string;
+}
+
+type Tab = {
+	id: string;
+	label: string;
+	skills: Skill[];
+};
+
+const { collections, class: className } = Astro.props;
+
+const allSkills = Array.from(
+	new Map(
+		collections.flatMap((collection) => collection.skills).map((skill) => [skill.name, skill]),
+	).values(),
+);
+
+const featuredNames = [
+	"TypeScript",
+	"Next.js",
+	"Astro",
+	"Go",
+	"PostgreSQL",
+	"Redis",
+	"Tailwind CSS",
+	"Playwright",
+	"OpenTelemetry",
+	"Cloudflare",
+];
+
+const featuredFromPreset = featuredNames
+	.map((name) => allSkills.find((skill) => skill.name === name))
+	.filter((skill): skill is Skill => Boolean(skill));
+
+const featuredSkills = featuredFromPreset.length >= 8 ? featuredFromPreset : allSkills.slice(0, 10);
+
+const slugify = (text: string) =>
+	text
+		.toLowerCase()
+		.replace(/&/g, "and")
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/(^-|-$)/g, "");
+
+const tabs: Tab[] = [
+	{ id: "featured", label: "Featured", skills: featuredSkills },
+	{ id: "all", label: "All", skills: allSkills },
+	...collections.map((collection) => ({
+		id: slugify(collection.title),
+		label: collection.title,
+		skills: collection.skills,
+	})),
+];
+---
+
+<section class={className} data-skills-tabs>
+	<div class="mb-4 flex flex-wrap gap-2" role="tablist" aria-label="Skill categories">
+		{
+			tabs.map((tab, index) => (
+				<button
+					type="button"
+					id={`skills-tab-${tab.id}`}
+					class="skills-tab border-border/60 text-muted-foreground hover:text-foreground data-[active=true]:bg-primary/10 data-[active=true]:text-foreground data-[active=true]:border-primary/40 rounded-full border px-3 py-1.5 text-xs font-medium tracking-wide transition-colors"
+					role="tab"
+					data-tab={tab.id}
+					aria-selected={index === 0 ? "true" : "false"}
+					aria-controls={`skills-panel-${tab.id}`}
+					data-active={index === 0 ? "true" : "false"}
+				>
+					{tab.label}
+				</button>
+			))
+		}
+	</div>
+
+	{
+		tabs.map((tab, index) => (
+			<div
+				id={`skills-panel-${tab.id}`}
+				class={cn("skills-panel", index !== 0 && "hidden")}
+				role="tabpanel"
+				aria-labelledby={`skills-tab-${tab.id}`}
+				data-panel={tab.id}
+			>
+				<div class="flex flex-wrap gap-2">
+					{tab.skills.map((skill) => (
+						<span class="bg-card text-foreground/90 border-border/60 inline-flex items-center rounded-full border px-3 py-1 text-sm">
+							{skill.name}
+						</span>
+					))}
+				</div>
+			</div>
+		))
+	}
+</section>
+
+<script>
+	const tabRoots = document.querySelectorAll("[data-skills-tabs]");
+
+	for (const root of tabRoots) {
+		const tabs = root.querySelectorAll<HTMLButtonElement>(".skills-tab");
+		const panels = root.querySelectorAll<HTMLElement>(".skills-panel");
+
+		for (const tab of tabs) {
+			tab.addEventListener("click", () => {
+				const id = tab.dataset.tab;
+				if (!id) return;
+
+				for (const item of tabs) {
+					const isActive = item.dataset.tab === id;
+					item.setAttribute("aria-selected", isActive ? "true" : "false");
+					item.dataset.active = isActive ? "true" : "false";
+				}
+
+				for (const panel of panels) {
+					panel.classList.toggle("hidden", panel.dataset.panel !== id);
+				}
+			});
+		}
+	}
+</script>

--- a/src/components/ui/AsideListPanel.astro
+++ b/src/components/ui/AsideListPanel.astro
@@ -1,0 +1,41 @@
+---
+import InfoPanel from "@/components/ui/InfoPanel.astro";
+
+type AsideItem = {
+	title: string;
+	meta?: string;
+	href?: string;
+};
+
+interface Props {
+	title: string;
+	items: AsideItem[];
+}
+
+const { title, items }: Props = Astro.props;
+---
+
+<InfoPanel title={title} contentClass="p-0">
+	<div class="divide-border/60 flex flex-col divide-y">
+		{
+			items.map((item) => {
+				const content = (
+					<article class="py-4">
+						<h3 class="text-sm leading-relaxed font-medium">{item.title}</h3>
+						{item.meta && (
+							<p class="text-muted-foreground mt-1 text-xs tracking-wide">{item.meta}</p>
+						)}
+					</article>
+				);
+
+				return item.href ? (
+					<a href={item.href} rel="noopener noreferrer" target="_blank">
+						{content}
+					</a>
+				) : (
+					content
+				);
+			})
+		}
+	</div>
+</InfoPanel>

--- a/src/components/ui/InfoPanel.astro
+++ b/src/components/ui/InfoPanel.astro
@@ -1,0 +1,20 @@
+---
+import { cn } from "@/lib/utils";
+
+interface Props {
+	title: string;
+	class?: string;
+	contentClass?: string;
+}
+
+const { title, class: className, contentClass }: Props = Astro.props;
+---
+
+<section class={className}>
+	<div class="border-b border-border/70 py-3">
+		<h2 class="text-muted-foreground text-xs font-medium tracking-widest uppercase">{title}</h2>
+	</div>
+	<div class={cn("p-4", contentClass)}>
+		<slot />
+	</div>
+</section>

--- a/src/lib/github-calendar.ts
+++ b/src/lib/github-calendar.ts
@@ -1,0 +1,100 @@
+export type Activity = {
+	date: string;
+	count: number;
+	level: 0 | 1 | 2 | 3 | 4;
+};
+
+export type ApiResponse = {
+	total: Record<string, number>;
+	contributions: Activity[];
+};
+
+export async function fetchGitHubContributions(
+	username: string,
+	year: number | "last" = "last",
+): Promise<Activity[]> {
+	const apiUrl = "https://github-contributions-api.jogruber.de/v4/";
+	const yearParam = String(year);
+
+	try {
+		const response = await fetch(`${apiUrl}${username}?y=${yearParam}`);
+
+		if (!response.ok) {
+			throw new Error(`Failed to fetch GitHub contributions: ${response.statusText}`);
+		}
+
+		const data = (await response.json()) as ApiResponse;
+		return data.contributions || [];
+	} catch (error) {
+		console.error("Error fetching GitHub contributions:", error);
+		return [];
+	}
+}
+
+export function groupByWeeks(
+	activities: Activity[],
+	weekStart: 0 | 1 = 0, // 0 = Sunday, 1 = Monday
+): Array<Array<Activity | undefined>> {
+	if (activities.length === 0) return [];
+
+	const sortedActivities = [...activities].sort((a, b) => a.date.localeCompare(b.date));
+	const firstActivity = sortedActivities[0];
+	const lastActivity = sortedActivities[sortedActivities.length - 1];
+	if (!firstActivity || !lastActivity) return [];
+
+	const firstDate = new Date(firstActivity.date);
+	const lastDate = new Date(lastActivity.date);
+
+	// Get to start of week
+	const startDate = new Date(firstDate);
+	const dayDiff = (startDate.getDay() - weekStart + 7) % 7;
+	startDate.setDate(startDate.getDate() - dayDiff);
+
+	// Get to end of week
+	const endDate = new Date(lastDate);
+	const endDayDiff = (6 - ((endDate.getDay() - weekStart + 7) % 7)) % 7;
+	endDate.setDate(endDate.getDate() + endDayDiff);
+
+	// Create activity map
+	const activityMap = new Map(activities.map((a) => [a.date, a]));
+
+	// Build weeks
+	const weeks: Array<Array<Activity | undefined>> = [];
+	const currentDate = new Date(startDate);
+
+	while (currentDate <= endDate) {
+		const week: Array<Activity | undefined> = [];
+
+		for (let i = 0; i < 7; i++) {
+			const dateStr = currentDate.toISOString().split("T")[0] || "";
+			week.push(activityMap.get(dateStr));
+			currentDate.setDate(currentDate.getDate() + 1);
+		}
+
+		weeks.push(week);
+	}
+
+	return weeks;
+}
+
+export function getActivityLevel(count: number, allCounts: number[]): 0 | 1 | 2 | 3 | 4 {
+	if (count === 0) return 0;
+
+	const maxCount = Math.max(...allCounts);
+	if (maxCount === 0) return 0;
+
+	const normalized = count / maxCount;
+	if (normalized < 0.25) return 1;
+	if (normalized < 0.5) return 2;
+	if (normalized < 0.75) return 3;
+	return 4;
+}
+
+export function formatDate(dateStr: string): string {
+	const date = new Date(`${dateStr}T00:00:00`);
+	return date.toLocaleDateString("id-ID", { day: "numeric", month: "short", year: "numeric" });
+}
+
+export function getTotalCount(activities: Activity[]): number {
+	return activities.reduce((sum, activity) => sum + activity.count, 0);
+}

--- a/src/lib/github-calendar.ts
+++ b/src/lib/github-calendar.ts
@@ -9,24 +9,112 @@ export type ApiResponse = {
 	contributions: Activity[];
 };
 
+type CacheEntry = {
+	data: Activity[];
+	fetchedAt: number;
+};
+
+type FetchGitHubContributionsOptions = {
+	forceRefresh?: boolean;
+	enableLogging?: boolean;
+};
+
+const GITHUB_CACHE_TTL_MS = 60 * 60 * 1000;
+const GITHUB_STALE_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const contributionsCache = new Map<string, CacheEntry>();
+const GITHUB_API_BASE_URL = "https://github-contributions-api.jogruber.de/v4/";
+
+export const GITHUB_CACHE_POLICY = {
+	sMaxAge: 60 * 60,
+	staleWhileRevalidate: 24 * 60 * 60,
+} as const;
+
+function getCacheKey(username: string, year: number | "last"): string {
+	return `${username}:${year}`;
+}
+
+function getCachedEntry(cacheKey: string): CacheEntry | undefined {
+	const entry = contributionsCache.get(cacheKey);
+	if (!entry) return undefined;
+
+	const age = Date.now() - entry.fetchedAt;
+	if (age > GITHUB_STALE_CACHE_TTL_MS) {
+		contributionsCache.delete(cacheKey);
+		return undefined;
+	}
+
+	return entry;
+}
+
+function logCacheEvent(enableLogging: boolean, message: string): void {
+	if (!enableLogging) return;
+	console.info(`[github-calendar] ${message}`);
+}
+
+async function fetchFromGitHubApi(username: string, year: number | "last"): Promise<Activity[]> {
+	const response = await fetch(`${GITHUB_API_BASE_URL}${username}?y=${String(year)}`);
+
+	if (!response.ok) {
+		throw new Error(`Failed to fetch GitHub contributions: ${response.statusText}`);
+	}
+
+	const data = (await response.json()) as ApiResponse;
+	return data.contributions || [];
+}
+
 export async function fetchGitHubContributions(
 	username: string,
 	year: number | "last" = "last",
+	options: FetchGitHubContributionsOptions = {},
 ): Promise<Activity[]> {
-	const apiUrl = "https://github-contributions-api.jogruber.de/v4/";
-	const yearParam = String(year);
+	const forceRefresh = options.forceRefresh ?? false;
+	const enableLogging = options.enableLogging ?? false;
+	const queryParams = new URLSearchParams({
+		username,
+		year: String(year),
+	});
+
+	if (forceRefresh) {
+		queryParams.set("force", "1");
+	}
+
+	if (enableLogging) {
+		queryParams.set("log", "1");
+	}
+
+	const cacheKey = getCacheKey(username, year);
+	const cachedEntry = getCachedEntry(cacheKey);
+
+	if (cachedEntry && Date.now() - cachedEntry.fetchedAt < GITHUB_CACHE_TTL_MS && !forceRefresh) {
+		logCacheEvent(enableLogging, `cache hit for ${cacheKey}`);
+		return cachedEntry.data;
+	}
+
+	if (forceRefresh) {
+		logCacheEvent(enableLogging, `force refresh requested for ${cacheKey}`);
+	} else {
+		logCacheEvent(enableLogging, `cache miss for ${cacheKey}`);
+	}
 
 	try {
-		const response = await fetch(`${apiUrl}${username}?y=${yearParam}`);
-
-		if (!response.ok) {
-			throw new Error(`Failed to fetch GitHub contributions: ${response.statusText}`);
-		}
-
-		const data = (await response.json()) as ApiResponse;
-		return data.contributions || [];
+		const contributions = await fetchFromGitHubApi(username, year);
+		contributionsCache.set(cacheKey, { data: contributions, fetchedAt: Date.now() });
+		logCacheEvent(
+			enableLogging,
+			`cache updated for ${cacheKey} with ${contributions.length} entries`,
+		);
+		return contributions;
 	} catch (error) {
 		console.error("Error fetching GitHub contributions:", error);
+
+		if (cachedEntry) {
+			console.warn("Using stale GitHub contribution cache after fetch failure");
+			logCacheEvent(enableLogging, `serving stale cache for ${cacheKey}`);
+			return cachedEntry.data;
+		}
+
+		logCacheEvent(enableLogging, `no cache fallback available for ${cacheKey}`);
+
 		return [];
 	}
 }

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,14 +3,31 @@ import SocialLinks from "@/components/common/SocialLinks.astro";
 import Certifications from "@/components/features/home/Certifications.astro";
 import Educations from "@/components/features/home/Educations.astro";
 import Experiences from "@/components/features/home/Experiences.astro";
-import ToolSection from "@/components/features/tools/ToolSection.astro";
+import GitHubCalendar from "@/components/features/home/GitHubCalendar.astro";
+import SkillsTabs from "@/components/features/home/SkillsTabs.astro";
+import AsideListPanel from "@/components/ui/AsideListPanel.astro";
 import Section from "@/components/ui/Section.astro";
+import siteConfig from "@/config/site-config";
 import AboutContent from "@/content/pages/about.md";
 import PageLayout from "@/layouts/BaseLayout.astro";
 import TECH_STACK from "@/lib/constants/tech-stack";
 import { getAboutPageData } from "@/lib/contents";
 
 const { experiences, educations, certifications } = await getAboutPageData();
+const currentWork = experiences.slice(0, 1);
+
+const currentWorkItems = currentWork.map((work) => ({
+	title: work.title,
+	meta: work.company,
+}));
+
+const githubProfile = siteConfig.socialLinks.find((social) => social.text === "GitHub")?.href;
+const githubUsername = githubProfile?.split("/").filter(Boolean).at(-1) ?? "masmuss";
+
+const githubCalendarTheme = {
+	light: ["rgba(235, 237, 240, 0.4)", "#c6e48b", "#7bc96f", "#239a3b", "#196127"],
+	dark: ["rgba(22, 27, 34, 0.8)", "#0e4429", "#006d32", "#26a641", "#39d353"],
+} as const;
 ---
 
 <PageLayout
@@ -21,10 +38,34 @@ const { experiences, educations, certifications } = await getAboutPageData();
 >
 	<div class="flex w-full flex-col gap-y-10">
 		<h1 class="sr-only">About Khoirul Fattah</h1>
-		<Section title="About Me">
-			<div class="custom-prose max-w-none">
-				<AboutContent />
+
+		<div class="grid w-full grid-cols-1 gap-8 lg:grid-cols-[minmax(0,5fr)_256px] lg:gap-10">
+			<div class="flex flex-col gap-y-10">
+				<Section title="About Me">
+					<div class="prose-sm prose-a:underline max-w-none underline-offset-2">
+						<AboutContent />
+					</div>
+				</Section>
+
+				<Section title="Contribution Activity">
+					<GitHubCalendar
+						username={githubUsername}
+						blockSize={10}
+						blockMargin={2}
+						showMonthLabels={true}
+						year="last"
+						theme={githubCalendarTheme}
+					/>
+				</Section>
 			</div>
+
+			<aside class="flex flex-col gap-6">
+				<AsideListPanel title="Current Work" items={currentWorkItems} />
+			</aside>
+		</div>
+
+		<Section title="Skills">
+			<SkillsTabs collections={TECH_STACK} />
 		</Section>
 
 		<Experiences experiences={experiences} />
@@ -32,20 +73,6 @@ const { experiences, educations, certifications } = await getAboutPageData();
 		<Educations educations={educations} />
 
 		<Certifications certifications={certifications} />
-
-		<Section title="Tech Stack">
-			<div class="flex flex-col gap-y-10">
-				{
-					TECH_STACK.map((stack) => (
-						<ToolSection
-							class="grid-cols-2 md:grid-cols-3"
-							title={stack.title}
-							tools={stack.skills}
-						/>
-					))
-				}
-			</div>
-		</Section>
 
 		<Section title="Get in Touch">
 			<div class="text-muted-foreground flex flex-col gap-y-4">


### PR DESCRIPTION
This pull request introduces several new UI components and enhancements to the `about` page, focusing on improving the presentation of skills and GitHub contributions, as well as modularizing sidebar panels. The main changes include adding a dynamic GitHub contributions calendar, a tabbed skills section, and a reusable aside list panel. Supporting utility functions and styles have also been implemented to facilitate these features.

**Key changes:**

**1. Features and UI Enhancements**
- Added a new `GitHubCalendar` component to visually display a user's GitHub contribution activity, including theming support for light and dark modes, month labels, and total contribution count.
- Introduced a `SkillsTabs` component that organizes skills into tabs (Featured, All, and by collection), with a custom tab-switching script for improved navigation.
- Created a reusable `AsideListPanel` component for displaying lists (e.g., current work) in a styled panel format.
- Updated the `InfoPanel` component to accept additional styling props for better layout control.

**2. About Page Refactor**
- Refactored the `about` page to use the new `GitHubCalendar`, `SkillsTabs`, and `AsideListPanel` components, replacing the previous static tech stack section and integrating dynamic data for current work and GitHub activity. [[1]](diffhunk://#diff-cb33463363c150558e340277672bb5c583640ddb38012f53a33ed69125d92038L6-R30) [[2]](diffhunk://#diff-cb33463363c150558e340277672bb5c583640ddb38012f53a33ed69125d92038R41-L49)

**3. Utility and Data Layer**
- Implemented `github-calendar.ts` in the library, providing functions for fetching, caching, and formatting GitHub contribution data, as well as utilities for grouping activities by week and calculating contribution levels.

These changes collectively modernize and modularize the about page, offering a more interactive and informative experience for users.