### PR TITLE
Develop

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -23,24 +23,29 @@
 	--font-mono: var(--font-ibm-plex-mono);
 	--container-2xl: 1400px;
 
-	/* Dracula Pro Palette - Base Colors */
-	--color-dracula-bg: #151417;
-	--color-dracula-fg: #f8f8f2;
-	--color-dracula-selection: #44475a;
-	--color-dracula-comment: #6272a4;
-	--color-dracula-cyan: #80ffea;
-	--color-dracula-green: #8aff80;
-	--color-dracula-orange: #ffca80;
-	--color-dracula-pink: #ff80bf;
-	--color-dracula-purple: #9580ff;
-	--color-dracula-red: #ff9580;
-	--color-dracula-yellow: #ffff80;
+	/* Flexoki accents (400 for light mode, 600 for dark mode use-cases) */
+	--color-flexoki-red-400: #d14d41;
+	--color-flexoki-red-600: #af3029;
+	--color-flexoki-orange-400: #da702c;
+	--color-flexoki-orange-600: #bc5215;
+	--color-flexoki-yellow-400: #d0a215;
+	--color-flexoki-yellow-600: #ad8301;
+	--color-flexoki-green-400: #879a39;
+	--color-flexoki-green-600: #66800b;
+	--color-flexoki-cyan-400: #3aa99f;
+	--color-flexoki-cyan-600: #24837b;
+	--color-flexoki-blue-400: #4385be;
+	--color-flexoki-blue-600: #205ea6;
+	--color-flexoki-purple-400: #8b7ec8;
+	--color-flexoki-purple-600: #5e409d;
+	--color-flexoki-magenta-400: #ce5d97;
+	--color-flexoki-magenta-600: #a02f6f;
 
 	/* Semantic colors mapping */
 	--color-border: hsl(var(--border) / 0.8);
 	--color-input: hsl(var(--input));
 	--color-ring: hsl(var(--ring));
-	--color-background: hsl(var(--background));
+	--color-background: var(--background);
 	--color-foreground: hsl(var(--foreground));
 	--color-primary: hsl(var(--primary));
 	--color-primary-foreground: hsl(var(--primary-foreground));
@@ -66,54 +71,48 @@
 		color-scheme: light;
 
 		&:not(.dark) {
-			--background: 0 0% 96.5%;
-			--foreground: 0 0% 8.6%;
-			--card: 0 0% 100%;
-			--card-foreground: 0 0% 8.6%;
-			--popover: 0 0% 100%;
-			--popover-foreground: 0 0% 8.6%;
-			--primary: 250 100% 75%;
-			--primary-foreground: 0 0% 98%;
-			--secondary: 0 0% 90.6%;
-			--secondary-foreground: 0 0% 8.6%;
-			--muted: 0 0% 90.6%;
-			--muted-foreground: 0 0% 30%;
-			--accent: 0 0% 90.6%;
-			--accent-foreground: 0 0% 8.6%;
-			--destructive: 0 72.22% 50.59%;
-			--destructive-foreground: 0 0% 98%;
-			--border: 0 0% 82%;
-			--input: 0 0% 82%;
-			--ring: 250 69% 42%;
+			--background: #fffcf0;
+			--foreground: 0 3% 6%;
+			--card: 48 100% 97%;
+			--card-foreground: 0 3% 6%;
+			--popover: 48 100% 97%;
+			--popover-foreground: 0 3% 6%;
+			--primary: 0 3% 6%;
+			--primary-foreground: 48 100% 97%;
+			--secondary: 50 14% 83%;
+			--secondary-foreground: 50 3% 42%;
+			--muted: 51 33% 92%;
+			--muted-foreground: 50 3% 42%;
+			--accent: 51 21% 88%;
+			--accent-foreground: 50 3% 42%;
+			--destructive: 3 62% 42%;
+			--destructive-foreground: 48 100% 97%;
+			--border: 50 14% 83%;
+			--input: 50 14% 83%;
+			--ring: 55 10% 79%;
 		}
 
 		&.dark {
 			color-scheme: dark;
-			/* Dracula Pro Implementation (Converted HEX to HSL) */
-			--background: 260 6% 8%; /* #151417 */
-			--foreground: 60 30% 96%; /* #f8f8f2 */
-			--card: 260 6% 12%;
-			--card-foreground: 60 30% 96%;
-			--popover: 260 6% 10%;
-			--popover-foreground: 60 30% 96%;
-			--primary: 250 100% 75%; /* #9580ff (Purple) */
-			--primary-foreground: 260 6% 8%;
-			--secondary: 231 14% 31%; /* #44475a (Selection) */
-			--secondary-foreground: 60 30% 96%;
-			--muted: 225 27% 51%; /* #6272a4 (Comment) */
-			--muted-foreground: 225 27% 85%;
-			--accent: 231 14% 31%; /* #44475a */
-			--accent-foreground: 60 30% 96%;
-			--destructive: 9 100% 75%; /* #ff9580 (Red) */
-			--destructive-foreground: 260 6% 8%;
-			--border: 240 6% 20%; /* #212024 (Hover/Darker border) */
-			--input: 240 6% 20%;
-			--ring: 250 100% 75%;
-
-			/* Icon theming - dark mode */
-			--nextjs-logo-color: #f8f8f2;
-			--jetbrains-text: #f8f8f2;
-			--better-auth-inner: #151417;
+			--background: #100f0f;
+			--foreground: 55 10% 79%;
+			--card: 0 3% 6%;
+			--card-foreground: 55 10% 79%;
+			--popover: 0 3% 6%;
+			--popover-foreground: 55 10% 79%;
+			--primary: 55 10% 79%;
+			--primary-foreground: 0 3% 6%;
+			--secondary: 40 3% 20%;
+			--secondary-foreground: 43 3% 52%;
+			--muted: 30 4% 11%;
+			--muted-foreground: 43 3% 52%;
+			--accent: 30 3% 15%;
+			--accent-foreground: 43 3% 52%;
+			--destructive: 5 61% 54%;
+			--destructive-foreground: 0 3% 6%;
+			--border: 40 3% 20%;
+			--input: 40 3% 20%;
+			--ring: 30 3% 24%;
 		}
 	}
 

--- a/src/components/features/blog/Comment.astro
+++ b/src/components/features/blog/Comment.astro
@@ -23,7 +23,7 @@
 
 		const script = document.createElement("script");
 		script.src = "https://giscus.app/client.js";
-		script.setAttribute("data-repo", "masmuss/khoirul.me");
+		script.setAttribute("data-repo", "masmuss/khoirul.site");
 		script.setAttribute("data-repo-id", "R_kgDOPKC8fg");
 		script.setAttribute("data-category", "General");
 		script.setAttribute("data-category-id", "DIC_kwDOPKC8fs4Ct6-3");

--- a/src/components/features/blog/PostPreview.astro
+++ b/src/components/features/blog/PostPreview.astro
@@ -13,7 +13,7 @@ const { post } = Astro.props;
 <li>
 	<a
 		href={getPostUrl(post)}
-		class="group -mx-3 flex flex-col gap-1 rounded-lg px-3 py-3 opacity-70 transition-opacity hover:opacity-100 sm:flex-row sm:items-baseline sm:gap-4"
+		class="group -mx-3 flex flex-col gap-1 rounded-lg px-3 py-3 opacity-90 transition-opacity hover:opacity-100 sm:flex-row sm:items-baseline sm:gap-4"
 		data-astro-reload
 	>
 		<span class="group-hover:text-foreground flex-1 font-medium transition-colors sm:line-clamp-1">

--- a/src/components/features/home/GitHubCalendar.astro
+++ b/src/components/features/home/GitHubCalendar.astro
@@ -1,10 +1,5 @@
 ---
-import {
-	fetchGitHubContributions,
-	formatDate,
-	getTotalCount,
-	groupByWeeks,
-} from "@/lib/github-calendar";
+import { fetchGitHubContributions, getTotalCount, groupByWeeks } from "@/lib/github-calendar";
 
 type CalendarTheme = {
 	light: readonly [string, string, string, string, string];
@@ -197,7 +192,7 @@ const topPadding = showMonthLabels ? blockSize + 8 : 0;
 	</div>
 </div>
 
-<style scoped>
+<style>
 	svg {
 		display: block;
 		margin: 0 auto;

--- a/src/components/features/home/SkillsTabs.astro
+++ b/src/components/features/home/SkillsTabs.astro
@@ -1,4 +1,5 @@
 ---
+import Button from "@/components/ui/Button.astro";
 import type { Skill, SkillCollection } from "@/lib/constants/tech-stack";
 import { cn } from "@/lib/utils";
 
@@ -62,18 +63,18 @@ const tabs: Tab[] = [
 	<div class="mb-4 flex flex-wrap gap-2" role="tablist" aria-label="Skill categories">
 		{
 			tabs.map((tab, index) => (
-				<button
-					type="button"
+				<Button
+					as="button"
 					id={`skills-tab-${tab.id}`}
-					class="skills-tab border-border/60 text-muted-foreground hover:text-foreground data-[active=true]:bg-primary/10 data-[active=true]:text-foreground data-[active=true]:border-primary/40 rounded-full border px-3 py-1.5 text-xs font-medium tracking-wide transition-colors"
+					class="skills-tab text-xs font-medium tracking-wide"
+					style="tab"
 					role="tab"
 					data-tab={tab.id}
 					aria-selected={index === 0 ? "true" : "false"}
 					aria-controls={`skills-panel-${tab.id}`}
 					data-active={index === 0 ? "true" : "false"}
-				>
-					{tab.label}
-				</button>
+					title={tab.label}
+				/>
 			))
 		}
 	</div>
@@ -89,7 +90,7 @@ const tabs: Tab[] = [
 			>
 				<div class="flex flex-wrap gap-2">
 					{tab.skills.map((skill) => (
-						<span class="bg-card text-foreground/90 border-border/60 inline-flex items-center rounded-full border px-3 py-1 text-sm">
+						<span class="bg-card text-foreground border-border/60 inline-flex items-center rounded-full border px-3 py-1 text-sm">
 							{skill.name}
 						</span>
 					))}

--- a/src/components/ui/Button.astro
+++ b/src/components/ui/Button.astro
@@ -1,28 +1,50 @@
 ---
 import { cn } from "@/lib/utils";
 
-interface Props {
-	as?: keyof HTMLElementTagNameMap;
+type Props = {
+	as?: "a" | "button";
 	class?: string;
 	title: string;
 	href?: string;
-	style?: "button" | "pill";
-}
+	style?: "button" | "pill" | "tab";
+	[key: string]: unknown;
+};
 
-const { as: Tag = "a", class: className, title, href, style = "button" }: Props = Astro.props;
+const { as = "a", class: className, title, href, style = "button", ...attrs }: Props = Astro.props;
+
+const baseClass =
+	"inline-flex items-center justify-center gap-x-1 border px-2 py-1 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+
+const variantClass: Record<NonNullable<Props["style"]>, string> = {
+	button:
+		"rounded-lg bg-card border-border text-foreground hover:bg-accent hover:border-accent-foreground",
+	pill: "rounded-xl bg-card border-border text-foreground hover:bg-accent hover:border-accent-foreground",
+	tab: cn(
+		"rounded-full border-border/60 bg-transparent text-muted-foreground hover:text-foreground data-[active=true]:border-primary/40 data-[active=true]:bg-primary/10 data-[active=true]:text-foreground",
+	),
+};
+
+const isButton = as === "button";
+const prefetchProps = href && !isButton ? { "data-astro-prefetch": true as const } : {};
 ---
 
-<Tag
-	class={cn(
-		className,
-		"inline-flex items-center gap-x-1 rounded-lg bg-primary-foreground border border-border px-2 py-1 text-sm transition-all hover:bg-accent hover:border-accent-foreground",
-		!href && "cursor-default",
-		style === "pill" && "rounded-xl",
-	)}
-	href={href}
-	data-astro-prefetch
->
-	<slot name="icon-before" />
-	<p>{title}</p>
-	<slot name="icon-after" />
-</Tag>
+{
+	isButton ? (
+		<button type="button" {...attrs} class={cn(baseClass, variantClass[style], className)}>
+			<slot name="icon-before" />
+			<span>{title}</span>
+			<slot name="icon-after" />
+		</button>
+	) : (
+		<a
+			{...prefetchProps}
+			href={href}
+			{...attrs}
+			class={cn(baseClass, variantClass[style], className)}
+		>
+			<slot name="icon-before" />
+			<span>{title}</span>
+			<slot name="icon-after" />
+		</a>
+	)
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -11,12 +11,11 @@ const { ...head } = Astro.props;
 <!doctype html>
 <html lang="en">
 	<head>
+		<ThemeProvider />
 		<BaseHead {...head} />
 		<ClientRouter />
 	</head>
 	<body class="bg-background flex flex-col justify-center antialiased transition-all">
-		<ThemeProvider />
-
 		<main
 			class="relative z-10 mx-auto flex min-h-screen w-screen max-w-2xl flex-col items-center px-5 leading-relaxed md:max-w-5xl md:px-10 lg:px-0"
 			transition:animate={fade({ duration: 300 })}


### PR DESCRIPTION
This pull request primarily updates the site's visual theme by switching from the Dracula Pro color palette to the Flexoki palette, refines several UI components for consistency and maintainability, and makes minor improvements to blog and layout features. The most significant changes are grouped below.

**Theme and Visual Updates:**

* Replaced the Dracula Pro color palette with Flexoki accent colors in `global.css`, updating both base colors and semantic color mappings for light and dark modes. This includes changes to background, foreground, and accent color variables for a more cohesive and modern look. [[1]](diffhunk://#diff-8e57e24fafbd8da9941d9aee878f522b211c70ca8a5a07d21766dcea0d1421b1L26-R48) [[2]](diffhunk://#diff-8e57e24fafbd8da9941d9aee878f522b211c70ca8a5a07d21766dcea0d1421b1L69-R115)

**UI Component Improvements:**

* Refactored the `Button.astro` component to support a new `"tab"` style variant, improved accessibility, and allowed for more flexible usage (e.g., as a button or link). Updated the API to accept additional props and adjusted styling logic accordingly.
* Updated `SkillsTabs.astro` to use the new `Button` component for tabs, ensuring consistent styling and improved semantics. Also slightly tweaked skill badge colors for better contrast. [[1]](diffhunk://#diff-be34d88b59307a19e5f45295d3797259ba358eefd64fe3bc040db77bb15bc1dbR2) [[2]](diffhunk://#diff-be34d88b59307a19e5f45295d3797259ba358eefd64fe3bc040db77bb15bc1dbL65-R77) [[3]](diffhunk://#diff-be34d88b59307a19e5f45295d3797259ba358eefd64fe3bc040db77bb15bc1dbL92-R93)

**Blog and Content Adjustments:**

* Changed the Giscus comments integration in `Comment.astro` to use the new repository name (`khoirul.site` instead of `khoirul.me`).
* Increased the default opacity of blog post previews for improved readability.

**Other Codebase Cleanups:**

* Removed unused imports in `GitHubCalendar.astro` and adjusted style scoping for maintainability. [[1]](diffhunk://#diff-e3a747b57e25696db2d2b0a9bf605a0e2a2bfb16adc217e40674f85999c30e48L2-R2) [[2]](diffhunk://#diff-e3a747b57e25696db2d2b0a9bf605a0e2a2bfb16adc217e40674f85999c30e48L200-R195)
* Moved the `ThemeProvider` component to the `<head>` in `BaseLayout.astro` for better initialization timing.