### PR TITLE
feat: self-contained RelatedPost with score-based algorithm

### DIFF
--- a/src/components/features/blog/RelatedPost.astro
+++ b/src/components/features/blog/RelatedPost.astro
@@ -7,14 +7,17 @@ import {
 	CardTitle
 } from "@/components/ui/card";
 import Heading from "@/components/ui/Heading.astro";
+import { getAllPosts, getRelatedPosts } from "@/lib/contents/post";
 import { getPostUrl } from "@/lib/utils";
 import type { CollectionPosts } from "@/types";
 
 interface Props {
-	relatedPosts: CollectionPosts[];
+	post: CollectionPosts;
 }
 
-const { relatedPosts } = Astro.props;
+const { post } = Astro.props;
+const allPosts = await getAllPosts();
+const relatedPosts = getRelatedPosts(allPosts, post);
 ---
 
 {
@@ -29,12 +32,14 @@ const { relatedPosts } = Astro.props;
 				Related Posts
 			</Heading>
 			<div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-				{relatedPosts.map((post) => (
-					<Card as="a" href={getPostUrl(post)} reload class="h-full">
+				{relatedPosts.map((relatedPost) => (
+					<Card as="a" href={getPostUrl(relatedPost)} reload class="h-full">
 						<CardHeader class="flex h-full flex-col items-stretch justify-between gap-3">
-							<CardTitle class="line-clamp-2">{post.data.title}</CardTitle>
+							<CardTitle class="line-clamp-2">
+								{relatedPost.data.title}
+							</CardTitle>
 							<CardDescription class="line-clamp-2">
-								<PostMetadata post={post} readTimeStyle="long" />
+								<PostMetadata post={relatedPost} readTimeStyle="long" />
 							</CardDescription>
 						</CardHeader>
 					</Card>

--- a/src/lib/contents/post.ts
+++ b/src/lib/contents/post.ts
@@ -1,5 +1,5 @@
-import { type CollectionEntry, getCollection } from "astro:content";
 import type { CollectionPosts } from "@/types";
+import { type CollectionEntry, getCollection } from "astro:content";
 
 const AVERAGE_READING_WORDS_PER_MINUTE = 200;
 
@@ -27,17 +27,36 @@ export async function getAllPosts(limit?: number) {
 
 export function getRelatedPosts(
 	posts: CollectionPosts[],
-	tags: string[],
-	title: string,
-	limit = 3
+	currentPost: CollectionPosts,
+	limit = 4
 ): CollectionPosts[] {
-	return posts
-		.filter((post) => {
-			const hasMatchingTags = post.data.tags.some((tag) => tags.includes(tag));
-			const hasMatchingTitle = post.data.title === title;
-			return hasMatchingTags && !hasMatchingTitle;
+	const currentTags = currentPost.data.tags;
+	const currentId = currentPost.id;
+	const currentCategory = currentId.split("/")[0];
+
+	const postsWithScore = posts
+		.filter((post) => post.id !== currentId)
+		.map((post) => {
+			let score = 0;
+
+			const matchingTags = post.data.tags.filter((tag) =>
+				currentTags.includes(tag)
+			);
+			score += matchingTags.length * 10;
+
+			const postCategory = post.id.split("/")[0];
+			if (currentCategory && postCategory && currentCategory === postCategory) {
+				score += 5;
+			}
+
+			return { post, score };
 		})
-		.slice(0, limit);
+		.filter((item) => item.score > 0)
+		.sort((a, b) => b.score - a.score)
+		.slice(0, limit)
+		.map((item) => item.post);
+
+	return postsWithScore;
 }
 
 export async function getPostsByPath(

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -1,30 +1,22 @@
 ---
-import { type CollectionEntry, render } from "astro:content";
+import { render } from "astro:content";
 import Comment from "@/components/features/blog/Comment.astro";
 import RelatedPost from "@/components/features/blog/RelatedPost.astro";
 import Toc from "@/components/features/blog/Toc.astro";
 import PostLayout from "@/layouts/BlogPost.astro";
-import { getAllPosts, getRelatedPosts } from "@/lib/contents/post";
+import { getAllPosts } from "@/lib/contents/post";
 import { getPostRouteId } from "@/lib/utils/post-route";
 import type { CollectionPosts } from "@/types";
-
-type Props = {
-	post: CollectionEntry<"post">;
-	relatedPosts: CollectionPosts[];
-};
 
 export async function getStaticPaths() {
 	const posts = await getAllPosts();
 	return posts.map((post: CollectionPosts) => ({
 		params: { id: getPostRouteId(post) },
-		props: {
-			post,
-			relatedPosts: getRelatedPosts(posts, post.data.tags, post.data.title, 4)
-		}
+		props: { post }
 	}));
 }
 
-const { post, relatedPosts } = Astro.props;
+const { post } = Astro.props;
 
 const { Content, headings } = await render(post);
 ---
@@ -49,7 +41,7 @@ const { Content, headings } = await render(post);
 		</article>
 	</div>
 	<footer class="mx-auto mt-16 max-w-3xl">
-		<RelatedPost relatedPosts={relatedPosts} />
+		<RelatedPost {post} />
 		<Comment />
 	</footer>
 </PostLayout>


### PR DESCRIPTION
This pull request updates how related blog posts are determined and displayed. Instead of passing precomputed related posts from the page, the logic is now encapsulated within the `RelatedPost` component itself. The related post selection algorithm has also been improved to use a scoring system based on shared tags and categories, providing more relevant recommendations.

**Related posts logic improvements:**

* Refactored `getRelatedPosts` in `post.ts` to accept the current post and all posts, and implemented a scoring system that prioritizes posts with more shared tags and the same category. Increased the default number of related posts to 4.
* The `RelatedPost` component now receives the current `post` instead of a list of related posts and computes related posts internally using `getAllPosts` and `getRelatedPosts`.

**Component and props updates:**

* Updated `RelatedPost.astro` to use the new `post` prop, and changed variable names in the rendering loop for clarity.
* Updated the blog post page (`[...id].astro`) to stop computing related posts in `getStaticPaths` and instead just pass the current post to the `RelatedPost` component. ([src/pages/blog/[...id].astroL2-R19](diffhunk://#diff-4213e78fbe53c7d33f5fca0b5b9df7d5013efb2f10b4b955da98162bbb60b3b7L2-R19), [src/pages/blog/[...id].astroL52-R44](diffhunk://#diff-4213e78fbe53c7d33f5fca0b5b9df7d5013efb2f10b4b955da98162bbb60b3b7L52-R44))

**Minor code cleanups:**

* Adjusted import order and removed unused imports in `post.ts` and `[...id].astro`. ([src/lib/contents/post.tsL1-R2](diffhunk://#diff-3c053cfb2e7d13532c4555c4856b93feb3f99303d93c5204fd3315dd8caddcfeL1-R2), [src/pages/blog/[...id].astroL2-R19](diffhunk://#diff-4213e78fbe53c7d33f5fca0b5b9df7d5013efb2f10b4b955da98162bbb60b3b7L2-R19))